### PR TITLE
bug fix for bitwise operators

### DIFF
--- a/adcc.pl
+++ b/adcc.pl
@@ -25,14 +25,23 @@ close($fh);
 # process at the named stage and output the code representation at that point 
 # in the process
 foreach my $flag (@flags) {
-	if( $flag eq "--lex") {$stopAfter = "lex";}
+	if( $flag eq "--cpp") {$stopAfter = "cpp";}
+	elsif( $flag eq "--lex") {$stopAfter = "lex";}
 	elsif( $flag eq "--parse") {$stopAfter = "parse";}
 	elsif( $flag eq "--tacky") {$stopAfter = "tacky";}
 	elsif( $flag eq "--codegen") {$stopAfter = "codegen";}
 }
 
 foreach my $file (@files) {
-	my $tokens = Tokenize($file);
+
+	my $outfile=$file ; 
+	$outfile =~ s/[.]c$/.i/;
+	`gcc -E -P $file -o $outfile`;
+	if( $stopAfter eq "cpp") {
+		next;
+	}
+
+	my $tokens = Tokenize($outfile);
 	if( $stopAfter eq "lex") {
 		WriteObject("$file.tok", $tokens);
 		next;
@@ -60,7 +69,7 @@ foreach my $file (@files) {
 	
 	my $lines = EmitObject($aast);
 	
-	my $outfile = $file;
+	$outfile = $file;
 
 	$outfile =~ s/[.]c$/.s/;
 	open(my $f, ">",$outfile) or die "could not open $outfile for writing";

--- a/lib/adcc/parser/x86_64aast.pm
+++ b/lib/adcc/parser/x86_64aast.pm
@@ -149,8 +149,8 @@ sub TranslateBinaryOp {
 		bitwise_or  => 'orl', 
 		bitwise_and => 'andl', 
 		bitwise_xor => 'xorl',
-		shift_left  => 'shll',
-		shift_right => 'shrl',
+		shift_left  => 'sall',
+		shift_right => 'sarl',
 
 	);
 	
@@ -174,7 +174,17 @@ sub TranslateBinaryOp {
 		}	
 		push @$instructions, {name => $ops{$operation->{operation}}, operands =>
 			[$operation->{right}] };
-	} else {
+	}
+	elsif($operation->{operation} eq "shift_left" or $operation->{operation} eq "shift_right") {
+		push @$instructions, {name => 'movl', operands =>
+			[ $operation->{right}, {type=>'register', value=>'ecx'} ] };
+		
+		push @$instructions, {name => $ops{$operation->{operation}}, operands =>
+			[ {type=>'register', value=>'cl'},{type=>'register', value=>'r11d'} ] };
+		
+		
+	} 
+	else {
 		push @$instructions, {name => $ops{$operation->{operation}}, operands =>
 			[$operation->{right}, {type=>'register', value=>'r11d'}] };
 	}
@@ -186,7 +196,7 @@ sub TranslateBinaryOp {
 	elsif($operation->{operation} eq 'divide') {
 		push @$instructions, {name => 'movl', operands => 
 			[ {type=>'register', value=>'eax'}, $operation->{dest} ] };	
-	}	
+	}
 	else{ 
 		push @$instructions, {name => 'movl', operands => 
 			[ {type=>'register', value=>'r11d'}, $operation->{dest} ] };	


### PR DESCRIPTION
i apparently missed the part in the book where my compiler needed to call the gcc preprocessor, and made poor assumptions about the shift instructions